### PR TITLE
Fix specification of executable's path

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-mono $(dirname $0)Builder.exe
+mono $(dirname $0)/Builder.exe


### PR DESCRIPTION
This pull request fixes a typo in `builder.sh`. The wrong path would be selected because of a missing forward slash.